### PR TITLE
Remove stale manifest artifact, add .gitignore, clean up CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Gradle
+.gradle/
+build/
+fwreader/.gradle/
+fwreader/build/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# macOS
+.DS_Store
+
+# Serialized manifests and user data (stored in ~/.fwreader/ at runtime)
+*.ser
+lastDir.txt

--- a/fwreader/CLAUDE.md
+++ b/fwreader/CLAUDE.md
@@ -77,4 +77,3 @@ A Gradle wrapper is present — use `./gradlew`:
 
 - `settings.gradle` has `rootProject.name = 'untitled'` — likely should be renamed
 - No tests exist yet
-- `src/main/resources/data/fwFileManifest.ser` is a leftover artifact — no longer used, can be deleted


### PR DESCRIPTION
- Delete fwFileManifest.ser leftover from resources (runtime data lives in ~/.fwreader/)
- Add .gitignore covering Gradle build dirs, IDE files, .DS_Store, and *.ser files
- Remove resolved known-issue entry from CLAUDE.md